### PR TITLE
fix(logger): Fix reference to ruby default Logger constant

### DIFF
--- a/lib/httpigeon/logger.rb
+++ b/lib/httpigeon/logger.rb
@@ -81,7 +81,7 @@ module HTTPigeon
     end
 
     def log_to_stdout(log_data)
-      Logger.new($stdout).log(1, log_data.to_json)
+      ::Logger.new($stdout).log(1, log_data.to_json)
     end
   end
 end


### PR DESCRIPTION
### What
When no `:event_logger` object is configured, the call out to ruby default Logger constant was clashing with constant name of HTTPigeon Logger.

### Why
Fix this so that users don't get unexpected/misleading error messages when they don't set the optional `:event_logger` config
