### PR TITLE
fix(request): Handle edge cases in response parsing

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,7 @@ require "httpigeon"
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
+require "pry"
 # Pry.start
 
 require "irb"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ SimpleCov.start do
 end
 
 require 'httpigeon'
+require 'pry'
 
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 # for more details on configuration


### PR DESCRIPTION
### What
Account for stuff like this:
```ruby
NoMethodError: undefined method `with_indifferent_access' for []:Array

      JSON.parse(response_body).with_indifferent_access
```

### Why
Not everyone designs proper json APIs
