### PR TITLE
refactor(request): Change return value to response object instead of parsed_response

### DIFF
--- a/lib/httpigeon.rb
+++ b/lib/httpigeon.rb
@@ -5,6 +5,7 @@ require "httpigeon/version"
 require "httpigeon/log_redactor"
 require "httpigeon/logger"
 require "httpigeon/request"
+require "httpigeon/response"
 
 module HTTPigeon
   extend self

--- a/lib/httpigeon/request.rb
+++ b/lib/httpigeon/request.rb
@@ -6,36 +6,34 @@ require_relative "middleware/httpigeon_logger"
 
 module HTTPigeon
   class Request
+    REQUEST_ID_HEADER = 'X-Request-Id'.freeze
+
     class << self
       def get(endpoint, query = {}, headers = {}, event_type = nil, log_filters = [])
         request = new(base_url: endpoint, headers: headers, event_type: event_type, log_filters: log_filters)
-        parsed_response = request.run(method: :get, path: '', payload: query) do |req|
+        request.run(method: :get, path: '', payload: query) do |req|
           yield(req) if block_given?
         end
-
-        HTTPigeon::Response.new(request, parsed_response, request.response)
       end
 
       def post(endpoint, payload, headers = {}, event_type = nil, log_filters = [])
         request = new(base_url: endpoint, headers: headers,  event_type: event_type, log_filters: log_filters)
-        parsed_response = request.run(method: :post, path: '', payload: payload) do |req|
+        request.run(method: :post, path: '', payload: payload) do |req|
           yield(req) if block_given?
         end
-
-        HTTPigeon::Response.new(request, parsed_response, request.response)
       end
     end
 
-    attr_reader :connection, :response, :parsed_response
+    attr_reader :connection, :response, :parsed_response, :base_url
 
     delegate :status, :body, to: :response, prefix: true
 
     def initialize(base_url:, options: nil, headers: nil, adapter: nil, logger: nil, event_type: nil, log_filters: nil)
-      @base_url = base_url
+      @base_url = URI.parse(base_url)
 
       request_headers = default_headers.merge(headers.to_h)
 
-      base_connection = Faraday.new(url: base_url).tap do |config|
+      base_connection = Faraday.new(url: base_url.to_s).tap do |config|
         config.headers.deep_merge!(request_headers)
         config.options.merge!(options.to_h)
         config.response :httpigeon_logger, logger if logger.is_a?(HTTPigeon::Logger)
@@ -60,53 +58,25 @@ module HTTPigeon
         connection.headers['Content-Type'] = 'application/json'
       end
 
-      @response = connection.send(method, path, payload) do |request|
+      connection.headers[REQUEST_ID_HEADER] = SecureRandom.uuid if HTTPigeon.auto_generate_request_id
+
+      raw_response = connection.send(method, path, payload) do |request|
         yield(request) if block_given?
       end
 
-      @parsed_response = parse_response || {}
+      @response = HTTPigeon::Response.new(self, raw_response)
     end
 
     private
 
     attr_reader :logger, :event_type, :log_filters
 
-    def parse_response
-      parsed_body = response_body.is_a?(String) ? JSON.parse(response_body) : response_body
-      deep_with_indifferent_access(parsed_body)
-    rescue JSON::ParserError
-      response_body.presence
-    end
-
-    def deep_with_indifferent_access(obj)
-      case obj
-      when Hash
-        obj.transform_values do |value|
-          deep_with_indifferent_access(value)
-        end.with_indifferent_access
-      when Array
-        obj.map { |item| deep_with_indifferent_access(item) }
-      else
-        obj
-      end
-    end
-
     def default_logger(event_type, log_filters)
       HTTPigeon::Logger.new(event_type: event_type, log_filters: log_filters)
     end
 
     def default_headers
-      HTTPigeon.auto_generate_request_id ? { 'Accept' => 'application/json', 'X-Request-Id' => SecureRandom.uuid } : { 'Accept' => 'application/json' }
-    end
-  end
-
-  class Response
-    attr_reader :request, :parsed_response, :raw_response
-
-    def initialize(request, parsed_response, raw_response)
-      @request = request
-      @parsed_response = parsed_response
-      @raw_response = raw_response
+      { 'Accept' => 'application/json' }
     end
   end
 end

--- a/lib/httpigeon/response.rb
+++ b/lib/httpigeon/response.rb
@@ -1,0 +1,45 @@
+module HTTPigeon
+  class Response
+    attr_reader :request, :parsed_response, :raw_response
+
+    delegate :to_h, :to_json, :with_indifferent_access, to: :parsed_response
+    delegate :status, :body, :env, to: :raw_response
+
+    def initialize(request, raw_response)
+      @request = request
+      @raw_response = raw_response
+
+      parse_response
+    end
+
+    def ==(other)
+      other == parsed_response || other.to_json == to_json || super
+    end
+
+    def [](key)
+      parsed_response[key]
+    end
+
+    private
+
+    def parse_response
+      parsed_body = body.is_a?(String) ? JSON.parse(body) : body
+      @parsed_response = deep_with_indifferent_access(parsed_body)
+    rescue JSON::ParserError
+      @parsed_response = body.presence || {}
+    end
+
+    def deep_with_indifferent_access(obj)
+      case obj
+      when Hash
+        obj.transform_values do |value|
+          deep_with_indifferent_access(value)
+        end.with_indifferent_access
+      when Array
+        obj.map { |item| deep_with_indifferent_access(item) }
+      else
+        obj
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What
- Change `HTTPigeon::Request#run` to return `HTTPigeon::Response` object instead of the parsed_response body (Hash)
- Implement relevant `Hash` methods on response object to maintain backwards compatibility
- Fix bug where a re-used request instance would always have the same request id for every `#run` call

### Why
Prep work for implementing circuit breaker feature (see #33)
