### PR TITLE
chore: Upgrade activesupport version

### DIFF
--- a/httpigeon.gemspec
+++ b/httpigeon.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 2.7.6"
-  spec.add_dependency "activesupport", "~> 7.0.4"
+  spec.add_dependency "activesupport", "~> 7.2.0"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.4"


### PR DESCRIPTION
### What

Upgrade to activesupport `7.2.0`

### Why

Rails 7.1 is only compatible with activesupport >= `7.1.0`

### Related Links

* [JIRA](https://dailypay.atlassian.net/browse/XXX)
