### PR TITLE
fix(ASV-4003): Fix default filter regex patterns

### DIFF
--- a/lib/httpigeon.rb
+++ b/lib/httpigeon.rb
@@ -12,11 +12,11 @@ module HTTPigeon
   extend self
 
   module FilterPatterns
-    EMAIL = "/(?'key'(email_?(address|Address)?=))(?'value'(.*\\.[a-z]+))(&|$)/".freeze
-    PASSWORD = "/(?'key'(pass_?(w|W)?ord=))(?'value'([^&$])*)/".freeze
-    USERNAME = "/(?'key'(user_?(n|N)?ame=))(?'value'([^&$])*)/".freeze
-    CLIENT_ID = "/(?'key'(client_?(id|Id)?=))(?'value'([^&$])*)/".freeze
-    CLIENT_SECRET = "/(?'key'(client_?(s|S)?ecret=))(?'value'([^&$])*)/".freeze
+    EMAIL = "/(?'key'(email_?(address|Address)?=))(?'value'([^&\\n\\r]*\\.[a-z]+))(?=&|$)/".freeze
+    PASSWORD = "/(?'key'(pass_?(w|W)?ord=))(?'value'([^&\\n\\r])*)/".freeze
+    USERNAME = "/(?'key'(user_?(n|N)?ame=))(?'value'([^&\\n\\r])*)/".freeze
+    CLIENT_ID = "/(?'key'(client_?(id|Id)?=))(?'value'([^&\\n\\r])*)/".freeze
+    CLIENT_SECRET = "/(?'key'(client_?(s|S)?ecret=))(?'value'([^&\\n\\r])*)/".freeze
   end
 
   class InvalidConfigurationError < StandardError; end

--- a/spec/httpigeon/log_redactor_spec.rb
+++ b/spec/httpigeon/log_redactor_spec.rb
@@ -183,12 +183,12 @@ describe HTTPigeon::LogRedactor do
       describe 'all patterns combined' do
         subject(:redactor) do
           described_class.new(log_filters: [
-            HTTPigeon::FilterPatterns::EMAIL,
-            HTTPigeon::FilterPatterns::PASSWORD,
-            HTTPigeon::FilterPatterns::USERNAME,
-            HTTPigeon::FilterPatterns::CLIENT_ID,
-            HTTPigeon::FilterPatterns::CLIENT_SECRET
-          ])
+                                HTTPigeon::FilterPatterns::EMAIL,
+                                HTTPigeon::FilterPatterns::PASSWORD,
+                                HTTPigeon::FilterPatterns::USERNAME,
+                                HTTPigeon::FilterPatterns::CLIENT_ID,
+                                HTTPigeon::FilterPatterns::CLIENT_SECRET
+                              ])
         end
 
         it 'redacts multiple sensitive params in one string' do

--- a/spec/httpigeon/log_redactor_spec.rb
+++ b/spec/httpigeon/log_redactor_spec.rb
@@ -57,6 +57,150 @@ describe HTTPigeon::LogRedactor do
       end
     end
 
+    context 'with default FilterPatterns' do
+      describe 'PASSWORD' do
+        subject(:redactor) { described_class.new(log_filters: [HTTPigeon::FilterPatterns::PASSWORD]) }
+
+        it 'redacts password containing a dollar sign literal' do
+          expect(redactor.redact('grant_type=client_credentials&password=$3cret!&scope=read')).to eq(
+            'grant_type=client_credentials&password=$3c...<redacted>&scope=read'
+          )
+        end
+
+        it 'redacts pass_word=value' do
+          expect(redactor.redact('pass_word=s3cret!')).to eq('pass_word=s3c...<redacted>')
+        end
+
+        it 'redacts passWord=value' do
+          expect(redactor.redact('passWord=s3cret!')).to eq('passWord=s3c...<redacted>')
+        end
+
+        it 'redacts password at end of string' do
+          expect(redactor.redact('user=joe&password=supersecretpassword')).to eq(
+            'user=joe&password=super...<redacted>'
+          )
+        end
+
+        it 'redacts empty password value' do
+          expect(redactor.redact('password=&next=login')).to eq('password=&next=login')
+        end
+
+        it 'does not match across newlines' do
+          expect(redactor.redact("password=evil\nSECRET=leaked&next=1")).to eq(
+            "password=<redacted>\nSECRET=leaked&next=1"
+          )
+        end
+      end
+
+      describe 'USERNAME' do
+        subject(:redactor) { described_class.new(log_filters: [HTTPigeon::FilterPatterns::USERNAME]) }
+
+        it 'redacts username=value' do
+          expect(redactor.redact('username=johndoe&action=login')).to eq(
+            'username=joh...<redacted>&action=login'
+          )
+        end
+
+        it 'redacts user_name=value' do
+          expect(redactor.redact('user_name=johndoe')).to eq('user_name=joh...<redacted>')
+        end
+
+        it 'redacts userName=value' do
+          expect(redactor.redact('userName=johndoe')).to eq('userName=joh...<redacted>')
+        end
+
+        it 'redacts username at end of string' do
+          expect(redactor.redact('token=abc&username=averylongusernamevalue')).to eq(
+            'token=abc&username=averyl...<redacted>'
+          )
+        end
+      end
+
+      describe 'CLIENT_ID' do
+        subject(:redactor) { described_class.new(log_filters: [HTTPigeon::FilterPatterns::CLIENT_ID]) }
+
+        it 'redacts client_id=value' do
+          expect(redactor.redact('client_id=abc123xyz&scope=read')).to eq(
+            'client_id=abc...<redacted>&scope=read'
+          )
+        end
+
+        it 'redacts clientId=value' do
+          expect(redactor.redact('clientId=abc123xyz')).to eq('clientId=abc...<redacted>')
+        end
+
+        it 'redacts clientid=value' do
+          expect(redactor.redact('clientid=abc123xyz')).to eq('clientid=abc...<redacted>')
+        end
+      end
+
+      describe 'CLIENT_SECRET' do
+        subject(:redactor) { described_class.new(log_filters: [HTTPigeon::FilterPatterns::CLIENT_SECRET]) }
+
+        it 'redacts client_secret=value' do
+          expect(redactor.redact('client_id=pub123&client_secret=topsecret123&grant_type=code')).to eq(
+            'client_id=pub123&client_secret=top...<redacted>&grant_type=code'
+          )
+        end
+
+        it 'redacts clientSecret=value' do
+          expect(redactor.redact('clientSecret=topsecret123')).to eq('clientSecret=top...<redacted>')
+        end
+
+        it 'redacts clientsecret=value' do
+          expect(redactor.redact('clientsecret=topsecret123')).to eq('clientsecret=top...<redacted>')
+        end
+      end
+
+      describe 'EMAIL' do
+        subject(:redactor) { described_class.new(log_filters: [HTTPigeon::FilterPatterns::EMAIL]) }
+
+        it 'redacts email=value' do
+          expect(redactor.redact('email=user@example.com&action=signup')).to eq(
+            'email=use...<redacted>&action=signup'
+          )
+        end
+
+        it 'redacts emailaddress=value' do
+          expect(redactor.redact('emailaddress=user@example.com')).to eq(
+            'emailaddress=use...<redacted>'
+          )
+        end
+
+        it 'redacts email_address=value' do
+          expect(redactor.redact('email_address=user@example.com')).to eq(
+            'email_address=use...<redacted>'
+          )
+        end
+
+        it 'redacts emailAddress=value' do
+          expect(redactor.redact('emailAddress=user@example.com')).to eq(
+            'emailAddress=use...<redacted>'
+          )
+        end
+      end
+
+      describe 'all patterns combined' do
+        subject(:redactor) do
+          described_class.new(log_filters: [
+            HTTPigeon::FilterPatterns::EMAIL,
+            HTTPigeon::FilterPatterns::PASSWORD,
+            HTTPigeon::FilterPatterns::USERNAME,
+            HTTPigeon::FilterPatterns::CLIENT_ID,
+            HTTPigeon::FilterPatterns::CLIENT_SECRET
+          ])
+        end
+
+        it 'redacts multiple sensitive params in one string' do
+          data = 'username=johndoe&password=s3cure!&client_id=app123abc&client_secret=secretvalue1&email=test@mail.com'
+
+          expect(redactor.redact(data)).to eq(
+            'username=joh...<redacted>&password=s3c...<redacted>&client_id=app...<redacted>&client_secret=sec...<redacted>&email=tes...<redacted>'
+          )
+        end
+      end
+    end
+
     context 'when filters include an invalid regex' do
       it 'raises an error' do
         filters = %w[/key_3=[0-9a-z]*/im::key_3=<redacted> key_4]


### PR DESCRIPTION
[JIRA](https://dailypay.atlassian.net/browse/ASV-4003)

## Summary
- Removes `$` from `[^&$]` character classes in PASSWORD, USERNAME, CLIENT_ID, and CLIENT_SECRET patterns so literal `$` characters in values are properly matched and redacted
- Replaces greedy `.*` in EMAIL pattern with `[^&\n\r]*` to prevent matching past `&` delimiters, and converts trailing `(&|$)` to a lookahead `(?=&|$)` so the `&` separator is preserved in output
- Adds `\n\r` to all negated character classes to prevent patterns from matching across newline boundaries
- Adds comprehensive test coverage for all default `FilterPatterns` (PASSWORD, USERNAME, CLIENT_ID, CLIENT_SECRET, EMAIL) including key-name variants, edge cases, and a combined integration test

## Test plan
- [x] Full RSpec suite passes (116 examples, 0 failures)
- [x] Coverage at 97.13% (above 95% threshold)
- [x] Verified `$` in password values is now captured and redacted
- [x] Verified EMAIL pattern preserves `&` delimiter in output
- [x] Verified patterns do not match across newline boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)